### PR TITLE
online regret is now usable.

### DIFF
--- a/client.h
+++ b/client.h
@@ -18,13 +18,11 @@ signals:
     void getRemotePlay(int x,int y);//the remote player played
     void waitForReply();//When received this signal, the window should lock the input
     void RemotePlayerdisconnected();//when the other client disconnected, this game is over
-    //void regretRequest();//remote player want to regret
-    //void excuteRegret();//excute the regret operation
+    void excuteRegret(int regreter);//excute the regret operation
+
 public slots:
     void sendLocalPlay(int x, int y);//use this to send a play
-    //void sendRegretRequest();//use this to send a regret
-    //void agreeRegret();
-    //void disagreeRegret();
+    void sendRegretRequest();//use this to send a regret
 
 private slots:
     void receivedData();
@@ -33,7 +31,8 @@ private slots:
 private:
     QTcpSocket *socket;
     int player;
-signals:
+
+    void regretRequest();//remote player want to regret
 };
 
 #endif // CLIENT_H

--- a/gobangserver/gobangserver.pro.user
+++ b/gobangserver/gobangserver.pro.user
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE QtCreatorProject>
-<!-- Written by QtCreator 4.2.1, 2017-06-04T15:36:39. -->
+<!-- Written by QtCreator 4.2.1, 2017-06-13T16:57:05. -->
 <qtcreator>
  <data>
   <variable>EnvironmentId</variable>
@@ -303,14 +303,14 @@
     <value type="int" key="PE.EnvironmentAspect.Base">2</value>
     <valuelist type="QVariantList" key="PE.EnvironmentAspect.Changes"/>
     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">gobangserver</value>
-    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
-    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4RunConfiguration:/home/parallels/Code/qt-projects/gobangserver/gobangserver.pro</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">gobangserver2</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4RunConfiguration:/home/parallels/Code/qt-projects/gobang/gobangserver/gobangserver.pro</value>
     <value type="bool" key="QmakeProjectManager.QmakeRunConfiguration.UseLibrarySearchPath">true</value>
     <value type="QString" key="Qt4ProjectManager.Qt4RunConfiguration.CommandLineArguments"></value>
     <value type="QString" key="Qt4ProjectManager.Qt4RunConfiguration.ProFile">gobangserver.pro</value>
     <value type="bool" key="Qt4ProjectManager.Qt4RunConfiguration.UseDyldImageSuffix">false</value>
     <value type="QString" key="Qt4ProjectManager.Qt4RunConfiguration.UserWorkingDirectory"></value>
-    <value type="QString" key="Qt4ProjectManager.Qt4RunConfiguration.UserWorkingDirectory.default">/home/parallels/Code/qt-projects/build-gobangserver-Desktop_Qt_5_8_0_GCC_64bit-Debug</value>
+    <value type="QString" key="Qt4ProjectManager.Qt4RunConfiguration.UserWorkingDirectory.default"></value>
     <value type="uint" key="RunConfiguration.QmlDebugServerPort">3768</value>
     <value type="bool" key="RunConfiguration.UseCppDebugger">false</value>
     <value type="bool" key="RunConfiguration.UseCppDebuggerAuto">true</value>

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -74,16 +74,18 @@ void MainWindow::on_actionOnline_PvP_triggered()
         //gobangboard >> ui->other_widgets
         QObject::connect(gobangboard,SIGNAL(blackTimeChange(int)),(this->ui->blackLCD),SLOT(display(int)));
         QObject::connect(gobangboard,SIGNAL(whiteTimeChange(int)),(this->ui->whiteLCD),SLOT(display(int)));
-
+        client *cli;
         if(!this->findChild<client *>(QString(),Qt::FindDirectChildrenOnly)){
-            client *cli = new client(this);
-            cli->setServer("localhost",33333);//according to the server's IP and port
+            cli= new client(this);
+
             QObject::connect(ui->boardui,SIGNAL(requestPlay(int,int)),cli,SLOT(sendLocalPlay(int,int)));
             QObject::connect(cli,SIGNAL(getRemotePlay(int,int)),gobangboard,SLOT(play(int,int)));
             QObject::connect(cli,SIGNAL(RemotePlayerReady(int)),ui->boardui,SLOT(newGame(int)));
-            //        QObject::connect(ui->regretButton,SIGNAL(clicked(void)),ui->boardui,SLOT(regretBinding(void)));
+            QObject::connect(ui->regretButton,SIGNAL(clicked(void)),cli,SLOT(sendRegretRequest()));
+            QObject::connect(cli,SIGNAL(excuteRegret(int)),gobangboard,SLOT(regret(int)));
             //        QObject::connect(ui->giveupButton,SIGNAL(clicked(void)),ui->boardui,SLOT(giveupBinding(void)));
         }
+        cli->setServer("localhost",33333);//according to the server's IP and port
     }
 
 }


### PR DESCRIPTION
网络悔棋已经可以了，并且将client作为全局变量，只初始化一次，只连接一次信号槽，在client内部判断是否处于连接状态。
在线游戏的结束还没有做好，建议在游戏结束的时候判断是否是从在线模式结束，如果是则断开连接以便下次连接